### PR TITLE
Revert "refactor: temporarily point jotai-devtools to rev3 branch"

### DIFF
--- a/src/tests/jotai-devtools.ts
+++ b/src/tests/jotai-devtools.ts
@@ -2,7 +2,7 @@ import { defineTest } from '../define-test.ts';
 
 export default defineTest({
   cloneCmd:
-    'curl -L https://github.com/jotaijs/jotai-devtools/archive/refs/heads/refactor/jotai-devtools-rev3.tar.gz | tar zx --strip-components=1',
+    'curl -L https://github.com/jotaijs/jotai-devtools/archive/HEAD.tar.gz | tar zx --strip-components=1',
   installCmd: 'pnpm install',
   overrideCmd: (pkg: string) => ['pnpm', 'add', pkg],
   testCmd: 'pnpm test',


### PR DESCRIPTION
Reverts jotaijs/jotai-ecosystem-ci#4 now that https://github.com/jotaijs/jotai-devtools/pull/218 PR is merged 